### PR TITLE
Send angle along with player location.

### DIFF
--- a/lib/Player.js
+++ b/lib/Player.js
@@ -1,9 +1,10 @@
 /* ************************************************
 ** GAME PLAYER CLASS
 ************************************************ */
-var Player = function (startX, startY) {
+var Player = function (startX, startY, startAngle) {
   var x = startX
   var y = startY
+  var angle = startAngle
   var id
 
   // Getters and setters
@@ -15,6 +16,10 @@ var Player = function (startX, startY) {
     return y
   }
 
+  var getAngle = function () {
+    return angle
+  }
+
   var setX = function (newX) {
     x = newX
   }
@@ -23,12 +28,18 @@ var Player = function (startX, startY) {
     y = newY
   }
 
+  var setAngle = function (newAngle) {
+    angle = newAngle
+  }
+
   // Define which variables and methods can be accessed
   return {
     getX: getX,
     getY: getY,
+    getAngle: getAngle,
     setX: setX,
     setY: setY,
+    setAngle: setAngle,
     id: id
   }
 }

--- a/lib/game.js
+++ b/lib/game.js
@@ -84,17 +84,17 @@ function onClientDisconnect () {
 // New player has joined
 function onNewPlayer (data) {
   // Create a new player
-  var newPlayer = new Player(data.x, data.y)
+  var newPlayer = new Player(data.x, data.y, data.angle)
   newPlayer.id = this.id
 
   // Broadcast new player to connected socket clients
-  this.broadcast.emit('new player', {id: newPlayer.id, x: newPlayer.getX(), y: newPlayer.getY()})
+  this.broadcast.emit('new player', {id: newPlayer.id, x: newPlayer.getX(), y: newPlayer.getY(), angle: newPlayer.getAngle()})
 
   // Send existing players to the new player
   var i, existingPlayer
   for (i = 0; i < players.length; i++) {
     existingPlayer = players[i]
-    this.emit('new player', {id: existingPlayer.id, x: existingPlayer.getX(), y: existingPlayer.getY()})
+    this.emit('new player', {id: existingPlayer.id, x: existingPlayer.getX(), y: existingPlayer.getY(), angle: existingPlayer.getAngle()})
   }
 
   // Add new player to the players array
@@ -115,9 +115,10 @@ function onMovePlayer (data) {
   // Update player position
   movePlayer.setX(data.x)
   movePlayer.setY(data.y)
+  movePlayer.setAngle(data.angle)
 
   // Broadcast updated position to connected socket clients
-  this.broadcast.emit('move player', {id: movePlayer.id, x: movePlayer.getX(), y: movePlayer.getY()})
+  this.broadcast.emit('move player', {id: movePlayer.id, x: movePlayer.getX(), y: movePlayer.getY(), angle: movePlayer.getAngle()})
 }
 
 /* ************************************************

--- a/public/js/RemotePlayer.js
+++ b/public/js/RemotePlayer.js
@@ -1,8 +1,9 @@
 /* global game */
 
-var RemotePlayer = function (index, game, player, startX, startY) {
+var RemotePlayer = function (index, game, player, startX, startY, startAngle) {
   var x = startX
   var y = startY
+  var angle = startAngle
 
   this.game = game
   this.health = 3
@@ -21,13 +22,13 @@ var RemotePlayer = function (index, game, player, startX, startY) {
   this.player.body.immovable = true
   this.player.body.collideWorldBounds = true
 
-  this.player.angle = game.rnd.angle()
+  this.player.angle = angle
 
-  this.lastPosition = { x: x, y: y }
+  this.lastPosition = { x: x, y: y, angle: angle }
 }
 
 RemotePlayer.prototype.update = function () {
-  if (this.player.x !== this.lastPosition.x || this.player.y !== this.lastPosition.y) {
+  if (this.player.x !== this.lastPosition.x || this.player.y !== this.lastPosition.y || this.player.angle != this.lastPosition.angle) {
     this.player.play('move')
     this.player.rotation = Math.PI + game.physics.arcade.angleToXY(this.player, this.lastPosition.x, this.lastPosition.y)
   } else {
@@ -36,6 +37,7 @@ RemotePlayer.prototype.update = function () {
 
   this.lastPosition.x = this.player.x
   this.lastPosition.y = this.player.y
+  this.lastPosition.angle = this.player.angle
 }
 
 window.RemotePlayer = RemotePlayer

--- a/public/js/game.js
+++ b/public/js/game.js
@@ -86,7 +86,7 @@ function onSocketConnected () {
   enemies = []
 
   // Send local player data to the game server
-  socket.emit('new player', { x: player.x, y: player.y })
+  socket.emit('new player', { x: player.x, y: player.y, angle: player.angle })
 }
 
 // Socket disconnected
@@ -106,7 +106,7 @@ function onNewPlayer (data) {
   }
 
   // Add new player to the remote players array
-  enemies.push(new RemotePlayer(data.id, game, player, data.x, data.y))
+  enemies.push(new RemotePlayer(data.id, game, player, data.x, data.y, data.angle))
 }
 
 // Move player
@@ -122,6 +122,7 @@ function onMovePlayer (data) {
   // Update player position
   movePlayer.player.x = data.x
   movePlayer.player.y = data.y
+  movePlayer.player.angle = data.angle
 }
 
 // Remove player
@@ -162,7 +163,7 @@ function update () {
       currentSpeed -= 4
     }
   }
-  
+
   game.physics.arcade.velocityFromRotation(player.rotation, currentSpeed, player.body.velocity)
 
   if (currentSpeed > 0) {
@@ -182,7 +183,7 @@ function update () {
     }
   }
 
-  socket.emit('move player', { x: player.x, y: player.y })
+  socket.emit('move player', { x: player.x, y: player.y, angle: player.angle })
 }
 
 function render () {


### PR DESCRIPTION
Made a minor enhancement to experiment with how the client/server model works.

This PR adds an 'angle' data component to the 'new player' and 'move player' events. Including the angle in the data allows all players to see up-to-date rotation information for all players on the playfield, even those that are rotating in place.
